### PR TITLE
Remove auth.restTokenPrivateKey from secure.config template

### DIFF
--- a/templates/secure.config.j2
+++ b/templates/secure.config.j2
@@ -1,6 +1,5 @@
 [auth]
         registerEmailPrivateKey = 9/sLDj5QS9Bh+M+jmXCK1YXLTWXZIEPy27I=
-        restTokenPrivateKey = 51PP2Nf95XerEVhOfL/U6geDDEZErMTBtaI=
 {% if gerrit_database_type == 'postgresql' %}
 [database]
         password = {{ gerrit_database_password }}


### PR DESCRIPTION
Support for token based REST authentication was removed in November
2012 [1] and the auth.restTokenPrivateKey setting has not been used
since version 2.6.  I'm not sure if it was even used in earlier
released versions.

The initialization of auth.restTokenPrivateKey was missed in that
removal, so a random value is still generated and set into the config
file when running the `init` program. It is not, however, used by
Gerrit anywhere.

[1] https://gerrit-review.googlesource.com/#/c/39283/

Change-Id: I84d40a8e5bb923bd50d1105217ba82afe9bd5da0
