### PR TITLE
Allow to configure plugins.allowRemoteAdmin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Role Variables
 | gerrit_ldap_group_scope                | subtree                                                          | Scope of the search performed for group objects (one, sub or subtree, base or object)                                     |
 | gerrit_ldap_group_pattern              | (cn=${groupname})                                                | Query pattern used when searching for an LDAP group to connect to a Gerrit group                                          |
 | gerrit_ldap_group_member_pattern       | (|(memberUid=${username})(gidNumber=${gidNumber}))               | Query pattern to use when searching for the groups that a user account is currently a member of                           |
-| gerrit_plugins_allow_remote_Admin      | false                                                            | Allow remote admin of plugins                                                                                             |
+| gerrit_plugins_allow_remote_admin      | false                                                            | Allow remote admin of plugins                                                                                             |
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Role Variables
 | gerrit_ldap_group_scope                | subtree                                                          | Scope of the search performed for group objects (one, sub or subtree, base or object)                                     |
 | gerrit_ldap_group_pattern              | (cn=${groupname})                                                | Query pattern used when searching for an LDAP group to connect to a Gerrit group                                          |
 | gerrit_ldap_group_member_pattern       | (|(memberUid=${username})(gidNumber=${gidNumber}))               | Query pattern to use when searching for the groups that a user account is currently a member of                           |
-
+| gerrit_plugins_allow_remote_Admin      | false                                                            | Allow remote admin of plugins                                                                                             |
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,5 @@ gerrit_ldap_group_base: ou=groups,dc=example,dc=com
 gerrit_ldap_group_scope: subtree
 gerrit_ldap_group_pattern: (cn=${groupname})
 gerrit_ldap_group_member_pattern: (|(memberUid=${username})(gidNumber=${gidNumber}))
+
+gerrit_plugins_allow_remote_admin: false

--- a/templates/gerrit.config.j2
+++ b/templates/gerrit.config.j2
@@ -36,3 +36,5 @@
         listenUrl = {{ gerrit_httpd_listen_url }}
 [cache]
         directory = cache
+[plugins]
+        allowRemoteAdmin = {{ gerrit_plugins_allow_remote_admin }}


### PR DESCRIPTION
The variable gerrit_plugins_allow_remote_admin can be set to
configure the plugins.allowRemoteAdmin setting in gerrit.config.

The default value is false, which is the default value used by
Gerrit when the setting is not present.

Change-Id: I6a7162bf3f53bb6a419da78efbd036007b0f6845
