### PR TITLE
Add task to create {{ gerrit_site }}/tmp

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,6 +105,15 @@
       {% for plugin in gerrit_install_plugins %} --install-plugin {{ plugin }} {% endfor %}
   tags: gerrit
 
+- name: Create Gerrit tmp directory
+  file: >
+    path={{ gerrit_site_dir }}/tmp
+    owner={{ gerrit_user }}
+    group={{ gerrit_group }}
+    mode=0755
+    state=directory
+  tags: gerrit
+
 - name: Save Initialization Options
   copy: >
     content="{{ gerrit_init_options }}"


### PR DESCRIPTION
Commit 02765c0 added persistence of the initialization options,
but was only tested on an existing site.

When using the role to initialize a new site, it fails with:

  Destination directory /var/gerrit/tmp does not exist

Add a task to ensure that the tmp folder gets created.

Change-Id: Id4659011aa4b6a89193fbe2ebca3436511f8cb32
