### PR TITLE
Configurable gerrit service params

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Role Variables
 | gerrit_ldap_group_member_pattern       | (|(memberUid=${username})(gidNumber=${gidNumber}))               | Query pattern to use when searching for the groups that a user account is currently a member of                           |
 | gerrit_ldap_group_name                 | cn                                                               | Name of the attribute on the group object which contains the value to use as the group name in Gerrit                     |
 | gerrit_plugins_allow_remote_admin      | false                                                            | Allow remote admin of plugins                                                                                             |
+| gerrit_user                            | gerrit                                                           | Username of the Gerrit service                                                                                            |
+| gerrit_group                           | gerrit                                                           | Group name of the Gerrit service                                                                                          |
+| gerrit_service_name                    | gerrit                                                           | Service name of the Gerrit service                                                                                        |
+| gerrit_site_dir                        | /var/gerrit                                                      | Gerrit site directory                                                                                                     |
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,11 @@ gerrit_version: 2.11.5
 gerrit_sha256sum: 2b252f2e2c65c4fe20eaac8f060f8fce89579d3fcdfb07b369e669578b77eeda
 gerrit_install_plugins: []
 
+gerrit_user: gerrit
+gerrit_group: gerrit
+gerrit_service_name: gerrit
+gerrit_site_dir: /var/gerrit
+
 gerrit_auth_type: 'OPENID'
 gerrit_canonical_web_url: 'http://localhost:8080/'
 gerrit_container_java_home: /usr/lib/jvm/java-8-openjdk-amd64/jre

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -163,7 +163,7 @@
 - name: Create Gerrit init file link
   file: >
     src={{ gerrit_site_dir }}/bin/gerrit.sh
-    dest=/etc/init.d/gerrit
+    dest=/etc/init.d/{{ gerrit_service_name }}
     state=link
   tags: gerrit
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,3 @@
 ---
 # vars file for gerrit
 
-gerrit_user: gerrit
-gerrit_group: gerrit
-gerrit_service_name: gerrit
-
-gerrit_site_dir: /var/gerrit


### PR DESCRIPTION
Allows to customize the Gerrit service's user name, group name, service name, and the site directory.
