### PR TITLE
Allow arbitrary items in {gerrit,secure}.config to be configured using ini_file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,5 @@ gerrit_extra_config_list:
   - { section: core, option: packedGitOpenFiles, value: 1024 }
 
 gerrit_extra_secure_config_list: []
+
+gerrit_service_after: syslog.target network.target

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,7 @@ gerrit_ldap_group_member_pattern: (|(memberUid=${username})(gidNumber=${gidNumbe
 gerrit_ldap_group_name: cn
 
 gerrit_plugins_allow_remote_admin: false
+gerrit_extra_config_list:
+  - { section: core, option: packedGitOpenFiles, value: 1024 }
+
+gerrit_extra_secure_config_list: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,7 @@
 # handlers file for gerrit
 
 - name: restart gerrit
-  service: name={{ gerrit_service_name }} state=restarted
+  systemd: name={{ gerrit_service_name }} state=restarted
   tags: gerrit
 
 - name: reindex gerrit

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -162,24 +162,33 @@
   tags: gerrit
 
 - name: Save Initialization Options
-  copy: >
-    content="{{ gerrit_init_options }}"
-    dest={{ gerrit_site_dir }}/tmp/init_options
-  register: init_options_log
+  copy:
+    content: >
+      java -jar /opt/gerrit/gerrit-{{ gerrit_version }}.war init
+      --batch
+      --no-auto-start
+      -d {{ gerrit_site_dir }}
+      {{ gerrit_init_options }}
+    dest: '{{ gerrit_site_dir }}/tmp/gerrit-init.sh'
+    mode: 0755
+  register: init_script
+  tags: gerrit
+
+- name: Stop Gerrit
+  become: yes
+  become_user: "{{ gerrit_user }}"
+  become_method: sudo
+  systemd: state=stopped name=gerrit
+  when: init_script.changed
   tags: gerrit
 
 - name: Initialize Gerrit
   become: yes
   become_user: "{{ gerrit_user }}"
   become_method: sudo
-  command: >
-    java -jar /opt/gerrit/gerrit.war init
-    --batch
-    --no-auto-start
-    -d {{ gerrit_site_dir }}
-    {{ gerrit_init_options }}
+  shell: '{{ gerrit_site_dir }}/tmp/gerrit-init.sh'
   register: initialization
-  when: init_options_log.changed
+  when: init_script.changed
   tags: gerrit
 
 - name: Reindexing Gerrit
@@ -200,13 +209,22 @@
   notify: restart gerrit
   tags: gerrit
 
-- name: Create Gerrit init file link
+- name: Delete Gerrit init file link
   file: >
-    src={{ gerrit_site_dir }}/bin/gerrit.sh
     dest=/etc/init.d/gerrit
-    state=link
+    state=absent
+  tags: gerrit
+
+- name: Install Gerrit systemd service file
+  template: >
+    src=gerrit.service.j2
+    dest=/etc/systemd/system/{{ gerrit_service_name }}.service
+    owner=root
+    group=root
+    mode=0644
+  notify: restart gerrit
   tags: gerrit
 
 - name: Ensure Gerrit service is started and enabled on boot
-  service: name={{ gerrit_service_name }} state=started enabled=yes
+  systemd: state=started name={{ gerrit_service_name }} enabled=yes
   tags: gerrit

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,6 +98,15 @@
   notify: restart gerrit
   tags: gerrit
 
+- name: Modify Gerrit configuration file
+  ini_file: >
+    dest={{ gerrit_site_dir }}/etc/gerrit.config
+    section={{ item.section }}
+    option={{ item.option }}
+    value={{ item.value }}
+    backup=yes
+  with_items: '{{ gerrit_extra_config_list }}'
+
 - name: Create Gerrit secure configuration file
   template: >
     src=secure.config.j2
@@ -107,6 +116,15 @@
     mode=0600
   notify: restart gerrit
   tags: gerrit
+
+- name: Modify Gerrit secure configuration file
+  ini_file: >
+    dest={{ gerrit_site_dir }}/etc/secure.config
+    section={{ item.section }}
+    option={{ item.option }}
+    value={{ item.value }}
+    backup=yes
+  with_items: '{{ gerrit_extra_secure_config_list }}'
 
 - name: Set Initialization Options
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,50 +88,6 @@
     state=directory
   tags: gerrit
 
-- name: Create Gerrit configuration file
-  template: >
-    src=gerrit.config.j2
-    dest={{ gerrit_site_dir }}/etc/gerrit.config
-    owner={{ gerrit_user }}
-    group={{ gerrit_group }}
-    mode=0644
-  notify: restart gerrit
-  tags: gerrit
-
-- name: Modify Gerrit configuration file
-  ini_file: >
-    dest={{ gerrit_site_dir }}/etc/gerrit.config
-    section={{ item.section }}
-    option={{ item.option }}
-    value={{ item.value }}
-    backup=yes
-  with_items: '{{ gerrit_extra_config_list }}'
-
-- name: Create Gerrit secure configuration file
-  template: >
-    src=secure.config.j2
-    dest={{ gerrit_site_dir }}/etc/secure.config
-    owner={{ gerrit_user }}
-    group={{ gerrit_group }}
-    mode=0600
-  notify: restart gerrit
-  tags: gerrit
-
-- name: Modify Gerrit secure configuration file
-  ini_file: >
-    dest={{ gerrit_site_dir }}/etc/secure.config
-    section={{ item.section }}
-    option={{ item.option }}
-    value={{ item.value }}
-    backup=yes
-  with_items: '{{ gerrit_extra_secure_config_list }}'
-
-- name: Set Initialization Options
-  set_fact:
-    gerrit_init_options: >
-      {% for plugin in gerrit_install_plugins %} --install-plugin {{ plugin }} {% endfor %}
-  tags: gerrit
-
 - name: Create Gerrit tmp directory
   file: >
     path={{ gerrit_site_dir }}/tmp
@@ -139,6 +95,70 @@
     group={{ gerrit_group }}
     mode=0755
     state=directory
+  tags: gerrit
+
+- name: Create temporary Gerrit configuration file
+  template: >
+    src=gerrit.config.j2
+    dest={{ gerrit_site_dir }}/tmp/gerrit.config
+    owner={{ gerrit_user }}
+    group={{ gerrit_group }}
+    mode=0644
+  changed_when: False
+  tags: gerrit
+
+- name: Modify temporary Gerrit configuration file
+  ini_file: >
+    dest={{ gerrit_site_dir }}/tmp/gerrit.config
+    section={{ item.section }}
+    option={{ item.option }}
+    value={{ item.value }}
+    backup=yes
+  with_items: '{{ gerrit_extra_config_list }}'
+  changed_when: False
+  tags: gerrit
+
+- name: Copy Gerrit configuration file
+  copy: >
+    src={{ gerrit_site_dir }}/tmp/gerrit.config
+    dest={{ gerrit_site_dir }}/etc/gerrit.config
+    remote_src=yes
+  notify: restart gerrit
+  tags: gerrit
+
+- name: Create temporary Gerrit secure configuration file
+  template: >
+    src=secure.config.j2
+    dest={{ gerrit_site_dir }}/tmp/secure.config
+    owner={{ gerrit_user }}
+    group={{ gerrit_group }}
+    mode=0600
+  changed_when: False
+  tags: gerrit
+
+- name: Modify temporary Gerrit secure configuration file
+  ini_file: >
+    dest={{ gerrit_site_dir }}/tmp/secure.config
+    section={{ item.section }}
+    option={{ item.option }}
+    value={{ item.value }}
+    backup=yes
+  with_items: '{{ gerrit_extra_secure_config_list }}'
+  changed_when: False
+  tags: gerrit
+
+- name: Copy Gerrit secure configuration file
+  copy: >
+    src={{ gerrit_site_dir }}/tmp/secure.config
+    dest={{ gerrit_site_dir }}/etc/secure.config
+    remote_src=yes
+  notify: restart gerrit
+  tags: gerrit
+
+- name: Set Initialization Options
+  set_fact:
+    gerrit_init_options: >
+      {% for plugin in gerrit_install_plugins %} --install-plugin {{ plugin }} {% endfor %}
   tags: gerrit
 
 - name: Save Initialization Options

--- a/templates/gerrit.service.j2
+++ b/templates/gerrit.service.j2
@@ -1,0 +1,17 @@
+# Systemd unit file for gerrit
+
+[Unit]
+Description=Gerrit Code Review
+After={{ gerrit_service_after }}
+
+[Service]
+Type=simple
+WorkingDirectory={{ gerrit_site_dir }}
+Environment=GERRIT_HOME={{ gerrit_site_dir }} JAVA_HOME={{ gerrit_container_java_home }}
+ExecStart=/usr/bin/java -Xmx2048m -jar ${GERRIT_HOME}/bin/gerrit.war daemon -d ${GERRIT_HOME}
+User={{ gerrit_user }}
+SyslogIdentifier=GerritCodeReview
+#StandardInput=socket
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Introduce `gerrit_extra_config_list` and `gerrit_extra_secure_config_list` as variables
containing a list of dictionaries containing `section`, `option` and `value` to allow
arbitrary items in gerrit.config and secure.config to be configured using `init_file`.
