### PR TITLE
Install bouncy castle crypto on Ubuntu

### DIFF
--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -1,2 +1,15 @@
 ---
 # tasks file for gerrit (Ubuntu specific)
+- name: Install bouncy castle crypto libraries
+  apt: name={{ item }} state=latest
+  with_itmes:
+    - libbcprov-java
+    - libbcpkix-java
+  notify: restart gerrit
+
+- name: Install symlink to bouncy castle into gerrit dir
+  file: path={{ gerrit_site_dir }}/lib/{{ item }}.jar src=/usr/share/java/{{ item }}.jar state=link
+  with_items:
+    - bcprov
+    - bcpkix
+  notify: restart gerrit


### PR DESCRIPTION
Without these libraries, Gerrit's SSH server only supports a known
insecure exchange method.

I have only tested on Ubuntu so I don't know if the issue also exists
on CentOS/Fedora as well.

Closes kbrebanov/ansible-gerrit#25
